### PR TITLE
Made optional metadata fields nullable in DB

### DIFF
--- a/migrations/1579892342411-MakeOptionalMetadataFieldsNullable.ts
+++ b/migrations/1579892342411-MakeOptionalMetadataFieldsNullable.ts
@@ -1,0 +1,24 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+const upQuery = `
+    ALTER TABLE staking.staking_pool_metadata ALTER COLUMN website DROP NOT NULL;
+    ALTER TABLE staking.staking_pool_metadata ALTER COLUMN bio DROP NOT NULL;
+    ALTER TABLE staking.staking_pool_metadata ALTER COLUMN location DROP NOT NULL;
+    ALTER TABLE staking.staking_pool_metadata ALTER COLUMN logo_url DROP NOT NULL;
+`
+const downQuery = `
+    ALTER TABLE staking.staking_pool_metadata ALTER COLUMN website SET NOT NULL;
+    ALTER TABLE staking.staking_pool_metadata ALTER COLUMN bio SET NOT NULL;
+    ALTER TABLE staking.staking_pool_metadata ALTER COLUMN location SET NOT NULL;
+    ALTER TABLE staking.staking_pool_metadata ALTER COLUMN logo_url SET NOT NULL;
+`
+
+export class MakeOptionalMetadataFieldsNullable1579892342411 implements MigrationInterface {
+
+    public async up(queryRunner: QueryRunner): Promise<any> {
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<any> {
+    }
+
+}

--- a/migrations/1579892342411-MakeOptionalMetadataFieldsNullable.ts
+++ b/migrations/1579892342411-MakeOptionalMetadataFieldsNullable.ts
@@ -16,9 +16,11 @@ const downQuery = `
 export class MakeOptionalMetadataFieldsNullable1579892342411 implements MigrationInterface {
 
     public async up(queryRunner: QueryRunner): Promise<any> {
+        await queryRunner.query(upQuery);
     }
 
     public async down(queryRunner: QueryRunner): Promise<any> {
+        await queryRunner.query(downQuery);
     }
 
 }

--- a/migrations/1579892342411-MakeOptionalMetadataFieldsNullable.ts
+++ b/migrations/1579892342411-MakeOptionalMetadataFieldsNullable.ts
@@ -15,8 +15,8 @@ const changedColumns = [
         newColumn: new TableColumn({ name: 'location', type: 'varchar', isNullable: true }),
     },
     {
-        oldColumn: new TableColumn({ name: 'location', type: 'varchar' }),
-        newColumn: new TableColumn({ name: 'location', type: 'varchar', isNullable: true }),
+        oldColumn: new TableColumn({ name: 'logo_url', type: 'varchar' }),
+        newColumn: new TableColumn({ name: 'logo_url', type: 'varchar', isNullable: true }),
     },
 ]
 const changedColumnsReverse = [
@@ -33,8 +33,8 @@ const changedColumnsReverse = [
         oldColumn: new TableColumn({ name: 'location', type: 'varchar', isNullable: true }),
     },
     {
-        newColumn: new TableColumn({ name: 'location', type: 'varchar' }),
-        oldColumn: new TableColumn({ name: 'location', type: 'varchar', isNullable: true }),
+        newColumn: new TableColumn({ name: 'logo_url', type: 'varchar' }),
+        oldColumn: new TableColumn({ name: 'logo_url', type: 'varchar', isNullable: true }),
     },
 ]
 

--- a/migrations/1579892342411-MakeOptionalMetadataFieldsNullable.ts
+++ b/migrations/1579892342411-MakeOptionalMetadataFieldsNullable.ts
@@ -1,26 +1,52 @@
-import { MigrationInterface, QueryRunner } from 'typeorm';
+import { MigrationInterface, QueryRunner, TableColumn } from 'typeorm';
 
-const upQuery = `
-    ALTER TABLE staking.staking_pool_metadata ALTER COLUMN website DROP NOT NULL;
-    ALTER TABLE staking.staking_pool_metadata ALTER COLUMN bio DROP NOT NULL;
-    ALTER TABLE staking.staking_pool_metadata ALTER COLUMN location DROP NOT NULL;
-    ALTER TABLE staking.staking_pool_metadata ALTER COLUMN logo_url DROP NOT NULL;
-`
-const downQuery = `
-    ALTER TABLE staking.staking_pool_metadata ALTER COLUMN website SET NOT NULL;
-    ALTER TABLE staking.staking_pool_metadata ALTER COLUMN bio SET NOT NULL;
-    ALTER TABLE staking.staking_pool_metadata ALTER COLUMN location SET NOT NULL;
-    ALTER TABLE staking.staking_pool_metadata ALTER COLUMN logo_url SET NOT NULL;
-`
+const targetTable = 'staking.staking_pool_metadata';
+const changedColumns = [
+    {
+        oldColumn: new TableColumn({ name: 'website', type: 'varchar' }),
+        newColumn: new TableColumn({ name: 'website', type: 'varchar', isNullable: true }),
+    },
+    {
+        oldColumn: new TableColumn({ name: 'bio', type: 'varchar' }),
+        newColumn: new TableColumn({ name: 'bio', type: 'varchar', isNullable: true }),
+    },
+    {
+        oldColumn: new TableColumn({ name: 'location', type: 'varchar' }),
+        newColumn: new TableColumn({ name: 'location', type: 'varchar', isNullable: true }),
+    },
+    {
+        oldColumn: new TableColumn({ name: 'location', type: 'varchar' }),
+        newColumn: new TableColumn({ name: 'location', type: 'varchar', isNullable: true }),
+    },
+]
+const changedColumnsReverse = [
+    {
+        newColumn: new TableColumn({ name: 'website', type: 'varchar' }),
+        oldColumn: new TableColumn({ name: 'website', type: 'varchar', isNullable: true }),
+    },
+    {
+        newColumn: new TableColumn({ name: 'bio', type: 'varchar' }),
+        oldColumn: new TableColumn({ name: 'bio', type: 'varchar', isNullable: true }),
+    },
+    {
+        newColumn: new TableColumn({ name: 'location', type: 'varchar' }),
+        oldColumn: new TableColumn({ name: 'location', type: 'varchar', isNullable: true }),
+    },
+    {
+        newColumn: new TableColumn({ name: 'location', type: 'varchar' }),
+        oldColumn: new TableColumn({ name: 'location', type: 'varchar', isNullable: true }),
+    },
+]
+
 
 export class MakeOptionalMetadataFieldsNullable1579892342411 implements MigrationInterface {
 
     public async up(queryRunner: QueryRunner): Promise<any> {
-        await queryRunner.query(upQuery);
+        await queryRunner.changeColumns(targetTable, changedColumns);
     }
 
     public async down(queryRunner: QueryRunner): Promise<any> {
-        await queryRunner.query(downQuery);
+        await queryRunner.changeColumns(targetTable, changedColumnsReverse);
     }
 
 }

--- a/src/entities/staking_pool_metadata.ts
+++ b/src/entities/staking_pool_metadata.ts
@@ -7,8 +7,8 @@ export class StakingPoolMetadata {
     @PrimaryColumn({ name: 'pool_id', type: 'varchar' })
     public poolId!: string;
     // Name of the pool
-    @Column({ name: 'name', type: 'varchar', nullable: true })
-    public name!: string | null;
+    @Column({ name: 'name', type: 'varchar' })
+    public name!: string;
     // website of the pool operator
     @Column({ name: 'website', type: 'varchar', nullable: true })
     public website!: string | null;


### PR DESCRIPTION
A null value for website in a staking pool's metadata was causing an error on insert. However, this is an optional field, so null values should be accepted.

Testing:
- [x] Tested on Hashalytics Scraper