### PR TITLE
Quick fix to prevent a failure on inserting transactions

### DIFF
--- a/src/scripts/utils/web3_utils.ts
+++ b/src/scripts/utils/web3_utils.ts
@@ -68,10 +68,6 @@ export class PullAndSaveWeb3 {
                     AND (
                         -- tx info hasn't been pulled
                         tx.transaction_hash IS NULL
-                        -- or tx where the block info has changed
-                        OR (
-                            tx.block_hash <> fe.block_hash
-                        )
                     )
                 ORDER BY 2 DESC
                 LIMIT 100)
@@ -88,10 +84,6 @@ export class PullAndSaveWeb3 {
                     AND (
                         -- tx info hasn't been pulled
                         tx.transaction_hash IS NULL
-                        -- or tx where the block info has changed
-                        OR (
-                            tx.block_hash <> terc20.block_hash
-                        )
                     )
                 ORDER BY 2 DESC
                 LIMIT 100)


### PR DESCRIPTION
A typeorm error is preventing transaction entities from being updated in the database if an entry already exists. This PR will eliminate cases where a transaction will be overwritten until a more permanent solution is found.

Testing:
- [x] Tested on hashalytics
