### PR TITLE
Fixed parsing of taker on TransformedERC20 events

### DIFF
--- a/src/parsers/events/transformed_erc20_events.ts
+++ b/src/parsers/events/transformed_erc20_events.ts
@@ -10,7 +10,7 @@ export function parseTransformedERC20Event(eventLog: RawLogEntry): TransformedER
 
     parseEvent(eventLog, transformedERC20Event);
 
-    const decodedLog = abiCoder.decodeLog(TRANSFORMED_ERC20_ABI.inputs, eventLog.data, eventLog.topics);
+    const decodedLog = abiCoder.decodeLog(TRANSFORMED_ERC20_ABI.inputs, eventLog.data, eventLog.topics[1]);
 
     transformedERC20Event.taker = decodedLog.taker.toLowerCase();
     transformedERC20Event.inputToken = decodedLog.inputToken.toLowerCase();


### PR DESCRIPTION
Fixed parsing of TransformedERC20 events. `taker` was being parsed incorrectly, since the decoder function was taking the function signature as the taker argument.