### PR TITLE
add contract call to differentiate VIP protocol

### DIFF
--- a/event-pipeline-bsc/src/parsers/events/swap_events.ts
+++ b/event-pipeline-bsc/src/parsers/events/swap_events.ts
@@ -24,10 +24,10 @@ export function parsePancakeSwapEvent(eventLog: RawLogEntry): ERC20BridgeTransfe
 
     eRC20BridgeTransferEvent.fromTokenAmount = amount0In.gt(amount1In) ? amount0In : amount1In; // taker_token_amount
     eRC20BridgeTransferEvent.toTokenAmount = amount0In.gt(amount1In) ? amount1Out : amount0Out; // maker_token_amount
-    eRC20BridgeTransferEvent.from = 'PancakeSwap'; // maker
+    eRC20BridgeTransferEvent.from = ''; // maker
     eRC20BridgeTransferEvent.to = decodedLog.to.toLowerCase(); // taker
     eRC20BridgeTransferEvent.directFlag = true;
-    eRC20BridgeTransferEvent.directProtocol = 'PancakeSwap';
+    eRC20BridgeTransferEvent.directProtocol = '';
 
     return eRC20BridgeTransferEvent;
 }

--- a/event-pipeline-bsc/src/scripts/utils/event_abi_utils.ts
+++ b/event-pipeline-bsc/src/scripts/utils/event_abi_utils.ts
@@ -88,10 +88,7 @@ export class PullAndSaveEventsByTopic {
                         const token1_i =   '0x'+ token1[i].slice(2).slice(token1[i].length == 66 ? 64 - 40 : 0)
                         parsedLogs[i].fromToken = parsedLogs[i].fromToken === '0' ? token0_i : token1_i;
                         parsedLogs[i].toToken = parsedLogs[i].toToken === '0' ? token0_i : token1_i;
-                        // logUtils.log(Web3Utils.hexToUtf8('0x' + protocolName[i].slice(98)).split(' ')) // [ '\u0012SushiSwap', 'LP', 'Token' ] [ '\u000bPancake', 'LPs' ]
-                        // logUtils.log(Web3Utils.hexToUtf8('0x' + protocolName[i].slice(98)).split(' ')[0]) // SushiSwap, \n Pancake
-                        // logUtils.log(Web3Utils.hexToUtf8('0x' + protocolName[i].slice(98)).split(' ')[1])
-
+                        
                         const protocolName_i = Web3Utils.hexToUtf8('0x' + protocolName[i].slice(98)).split('LP')[0].split(' ')[0].slice(1);
                         parsedLogs[i].from = protocolName_i.includes('Swap')? protocolName_i: (protocolName_i + 'Swap');
                         parsedLogs[i].directProtocol = protocolName_i.includes('Swap')? protocolName_i: (protocolName_i + 'Swap');

--- a/event-pipeline-bsc/src/scripts/utils/event_abi_utils.ts
+++ b/event-pipeline-bsc/src/scripts/utils/event_abi_utils.ts
@@ -83,16 +83,19 @@ export class PullAndSaveEventsByTopic {
                     const protocolName = await web3Source.callContractMethodsAsync(contractCallProtocolNameArray);
 
                     for (var i = 0; i < parsedLogs.length; i++) {
-
-                        const token0_i =   '0x'+ token0[i].slice(2).slice(token0[i].length == 66 ? 64 - 40 : 0);
-                        const token1_i =   '0x'+ token1[i].slice(2).slice(token1[i].length == 66 ? 64 - 40 : 0);
+                        const token0_i = '0x' + token0[i].slice(2).slice(token0[i].length == 66 ? 64 - 40 : 0);
+                        const token1_i = '0x' + token1[i].slice(2).slice(token1[i].length == 66 ? 64 - 40 : 0);
                         parsedLogs[i].fromToken = parsedLogs[i].fromToken === '0' ? token0_i : token1_i;
                         parsedLogs[i].toToken = parsedLogs[i].toToken === '0' ? token0_i : token1_i;
 
-                        const protocolName_i = Web3Utils.hexToUtf8('0x' + protocolName[i].slice(98)).split('LP')[0].split(' ')[0].slice(1);
-                        parsedLogs[i].from = protocolName_i.includes('Swap')? protocolName_i: (protocolName_i + 'Swap');
-                        parsedLogs[i].directProtocol = protocolName_i.includes('Swap')? protocolName_i: (protocolName_i + 'Swap');
-
+                        const protocolName_i = Web3Utils.hexToUtf8('0x' + protocolName[i].slice(98))
+                            .split('LP')[0]
+                            .split(' ')[0]
+                            .slice(1);
+                        parsedLogs[i].from = protocolName_i.includes('Swap') ? protocolName_i : protocolName_i + 'Swap';
+                        parsedLogs[i].directProtocol = protocolName_i.includes('Swap')
+                            ? protocolName_i
+                            : protocolName_i + 'Swap';
                     }
                 }
 

--- a/event-pipeline-bsc/src/scripts/utils/event_abi_utils.ts
+++ b/event-pipeline-bsc/src/scripts/utils/event_abi_utils.ts
@@ -6,6 +6,7 @@ import { RawLogEntry } from 'ethereum-types';
 
 import { MAX_BLOCKS_TO_SEARCH, START_BLOCK_OFFSET } from '../../config';
 import { LastBlockProcessed } from '../../entities';
+const Web3Utils = require('web3-utils');
 
 export interface DeleteOptions {
     isDirectTrade?: boolean;
@@ -56,6 +57,8 @@ export class PullAndSaveEventsByTopic {
                     var contractCallToken0Array = [];
                     var contractCallToken1Array = [];
 
+                    var contractCallProtocolNameArray = [];
+
                     for (var index in parsedLogs) {
                         const contractCallToken0: ContractCallInfo = {
                             to: (parsedLogs[index] as any).contractAddress,
@@ -68,13 +71,31 @@ export class PullAndSaveEventsByTopic {
                             data: '0xd21220a7',
                         };
                         contractCallToken1Array.push(contractCallToken1);
+
+                        const contractCallProtocolName: ContractCallInfo = {
+                            to: (parsedLogs[index] as any).contractAddress,
+                            data: '0x06fdde03',
+                        };
+                        contractCallProtocolNameArray.push(contractCallProtocolName);
                     }
                     const token0 = await web3Source.callContractMethodsAsync(contractCallToken0Array);
                     const token1 = await web3Source.callContractMethodsAsync(contractCallToken1Array);
+                    const protocolName = await web3Source.callContractMethodsAsync(contractCallProtocolNameArray);
 
                     for (var i = 0; i < parsedLogs.length; i++) {
-                        parsedLogs[i].fromToken = parsedLogs[i].fromToken === '0' ? token0[i] : token1[i];
-                        parsedLogs[i].toToken = parsedLogs[i].toToken === '0' ? token0[i] : token1[i];
+
+                        const token0_i =   '0x'+ token0[i].slice(2).slice(token0[i].length == 66 ? 64 - 40 : 0)
+                        const token1_i =   '0x'+ token1[i].slice(2).slice(token1[i].length == 66 ? 64 - 40 : 0)
+                        parsedLogs[i].fromToken = parsedLogs[i].fromToken === '0' ? token0_i : token1_i;
+                        parsedLogs[i].toToken = parsedLogs[i].toToken === '0' ? token0_i : token1_i;
+                        // logUtils.log(Web3Utils.hexToUtf8('0x' + protocolName[i].slice(98)).split(' ')) // [ '\u0012SushiSwap', 'LP', 'Token' ] [ '\u000bPancake', 'LPs' ]
+                        // logUtils.log(Web3Utils.hexToUtf8('0x' + protocolName[i].slice(98)).split(' ')[0]) // SushiSwap, \n Pancake
+                        // logUtils.log(Web3Utils.hexToUtf8('0x' + protocolName[i].slice(98)).split(' ')[1])
+
+                        const protocolName_i = Web3Utils.hexToUtf8('0x' + protocolName[i].slice(98)).split('LP')[0].split(' ')[0].slice(1);
+                        parsedLogs[i].from = protocolName_i.includes('Swap')? protocolName_i: (protocolName_i + 'Swap');
+                        parsedLogs[i].directProtocol = protocolName_i.includes('Swap')? protocolName_i: (protocolName_i + 'Swap');
+
                     }
                 }
 

--- a/event-pipeline-bsc/src/scripts/utils/event_abi_utils.ts
+++ b/event-pipeline-bsc/src/scripts/utils/event_abi_utils.ts
@@ -84,11 +84,11 @@ export class PullAndSaveEventsByTopic {
 
                     for (var i = 0; i < parsedLogs.length; i++) {
 
-                        const token0_i =   '0x'+ token0[i].slice(2).slice(token0[i].length == 66 ? 64 - 40 : 0)
-                        const token1_i =   '0x'+ token1[i].slice(2).slice(token1[i].length == 66 ? 64 - 40 : 0)
+                        const token0_i =   '0x'+ token0[i].slice(2).slice(token0[i].length == 66 ? 64 - 40 : 0);
+                        const token1_i =   '0x'+ token1[i].slice(2).slice(token1[i].length == 66 ? 64 - 40 : 0);
                         parsedLogs[i].fromToken = parsedLogs[i].fromToken === '0' ? token0_i : token1_i;
                         parsedLogs[i].toToken = parsedLogs[i].toToken === '0' ? token0_i : token1_i;
-                        
+
                         const protocolName_i = Web3Utils.hexToUtf8('0x' + protocolName[i].slice(98)).split('LP')[0].split(' ')[0].slice(1);
                         parsedLogs[i].from = protocolName_i.includes('Swap')? protocolName_i: (protocolName_i + 'Swap');
                         parsedLogs[i].directProtocol = protocolName_i.includes('Swap')? protocolName_i: (protocolName_i + 'Swap');

--- a/pipeline-utils/src/sources/web3.ts
+++ b/pipeline-utils/src/sources/web3.ts
@@ -122,7 +122,7 @@ export class Web3Source {
             return new Promise((resolve, reject) => {
                 let req = this._web3.eth.call.request(contractCall, (err: any, data: String) => {
                     if (err) reject(err);
-                    else resolve(`0x${data.slice(2).slice(data.length == 66 ? 64 - 40 : 0)}`);
+                    else resolve(data);
                 });
                 batch.add(req);
             });


### PR DESCRIPTION
- change the VIP swap source info to be empty first, then fill in after contract call checking the LP contract name
- the string matching part is hectic. might cause error in the future if we integrate future forks. but this is the best approach with current knowledge.