### PR TITLE
Add Uniswap Raw Transactions

### DIFF
--- a/packages/event-pipeline/migrations/1616456659271-AddUniswapRawSwaps.ts
+++ b/packages/event-pipeline/migrations/1616456659271-AddUniswapRawSwaps.ts
@@ -1,0 +1,79 @@
+import { MigrationInterface, QueryRunner, Table } from 'typeorm';
+
+const eventsUniswapPairsTable = new Table({
+    name: 'events.uniswap_pairs',
+    columns: [
+        { name: 'contract_address', type: 'varchar', isPrimary: true },
+        { name: 'token0_address', type: 'varchar' },
+        { name: 'token1_address', type: 'varchar' },
+        { name: 'block_number', type: 'bigint' }
+    ],
+});
+
+const createUniswapPairsIndexQuery = `
+    CREATE INDEX uniswap_pairs_token0_index
+    ON events.uniswap_pairs (token0_address);
+
+    CREATE INDEX uniswap_pairs_token1_index
+    ON events.uniswap_pairs (token1_address);
+`;
+
+const dropUniswapPairsIndexQuery = `
+    DROP INDEX events.uniswap_pairs_token0_index;
+    DROP INDEX events.uniswap_pairs_token1_index;
+`;
+
+const eventsUniswapSwapEventsTable = new Table({
+    name: 'events.uniswap_swap_events',
+    columns: [
+        { name: 'observed_timestamp', type: 'bigint' },
+        { name: 'contract_address', type: 'varchar' },
+        { name: 'transaction_hash', type: 'varchar', isPrimary: true },
+        { name: 'transaction_index', type: 'bigint' },
+        { name: 'log_index', type: 'bigint', isPrimary: true },
+        { name: 'block_hash', type: 'varchar' },
+        { name: 'block_number', type: 'bigint' },
+        { name: 'amount0_in', type: 'numeric' },
+        { name: 'amount1_in', type: 'numeric' },
+        { name: 'amount0_out', type: 'numeric' },
+        { name: 'amount1_out', type: 'numeric' },
+        { name: 'from', type: 'varchar' },
+        { name: 'to', type: 'varchar' },
+    ],
+});
+
+const createUniswapSwapsIndexQuery = `
+    CREATE INDEX uniswap_swaps_transaction_hash_index
+    ON events.uniswap_swap_events (transaction_hash);
+
+    CREATE INDEX uniswap_swaps_block_number_index
+    ON events.uniswap_swap_events (block_number);
+
+    CREATE INDEX uniswap_swaps_contract_address_index
+    ON events.uniswap_swap_events (contract_address);
+`;
+
+const dropUniswapSwapsIndexQuery = `
+    DROP INDEX events.uniswap_swaps_transaction_hash_index;
+    DROP INDEX events.uniswap_swaps_block_number_index;
+    DROP INDEX events.uniswap_swaps_contract_address_index;
+`;
+
+export class AddUniswapRawSwaps1616456659271 implements MigrationInterface {
+
+    public async up(queryRunner: QueryRunner): Promise<any> {
+        await queryRunner.createTable(eventsUniswapPairsTable);
+        await queryRunner.query(createUniswapPairsIndexQuery);
+
+        await queryRunner.createTable(eventsUniswapSwapEventsTable);
+        await queryRunner.query(createUniswapSwapsIndexQuery);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<any> {
+        await queryRunner.query(dropUniswapSwapsIndexQuery);
+        await queryRunner.dropTable(eventsUniswapSwapEventsTable);
+
+        await queryRunner.query(dropUniswapPairsIndexQuery);
+        await queryRunner.dropTable(eventsUniswapPairsTable);
+    }
+}

--- a/packages/event-pipeline/migrations/1616605371056-AddUniswapETH-USDTPair.ts
+++ b/packages/event-pipeline/migrations/1616605371056-AddUniswapETH-USDTPair.ts
@@ -1,0 +1,28 @@
+import {MigrationInterface, QueryRunner} from "typeorm";
+
+const insertUniswapETH_USDTPair = `
+    INSERT INTO events.uniswap_pairs VALUES (
+      '0x0d4a11d5eeaac28ec3f61d100daf4d40471f1852',
+      '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
+      '0xdac17f958d2ee523a2206206994597c13d831ec7',
+      10093341
+    );
+`;
+
+const deleteUniswapETH_USDTPair = `
+    DELETE FROM events.uniswap_pairs
+    WHERE contract_address = '0x0d4a11d5eeaac28ec3f61d100daf4d40471f1852';
+`;
+
+
+export class AddUniswapETHUSDTPair1616605371056 implements MigrationInterface {
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+      await queryRunner.query(insertUniswapETH_USDTPair);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+      await queryRunner.query(deleteUniswapETH_USDTPair);
+    }
+
+}

--- a/packages/event-pipeline/sql/uniswap_swap_events_normalized_view.sql
+++ b/packages/event-pipeline/sql/uniswap_swap_events_normalized_view.sql
@@ -1,0 +1,29 @@
+-- Show Uniswap Swap Events in a format similar to other events
+
+-- Uniswap Pair's Swap Event always includes in and out for both tokens. In the extracted data, there there is always only one token with amount greater than 0 as input or output. In this query I'll assume this is always true, but we need to confirm this
+CREATE OR REPLACE VIEW events.uniswap_swap_events_normalized AS (
+  SELECT
+    observed_timestamp,
+    uniswap_swap_events.contract_address,
+    transaction_hash,
+    transaction_index,
+    log_index,
+    block_hash,
+    uniswap_swap_events.block_number,
+    CASE
+      WHEN amount0_in > 0 THEN
+        token0_address
+      ELSE
+        token1_address
+    END AS from_token,
+    CASE
+      WHEN amount0_out > 0 THEN
+        token0_address
+      ELSE
+        token1_address
+    END AS to_token,
+    GREATEST(amount0_in, amount1_in) AS from_token_amount,
+    GREATEST(amount0_out, amount1_out) AS to_token_amount
+  FROM events.uniswap_swap_events
+  JOIN events.uniswap_pairs ON uniswap_swap_events.contract_address = uniswap_pairs.contract_address
+);

--- a/packages/event-pipeline/src/constants.ts
+++ b/packages/event-pipeline/src/constants.ts
@@ -29,6 +29,7 @@ export const V4_CANCEL_START_BLOCK = 11674215; // first seen block - 1
 export const V4_CANCEL_EVENT_TOPIC = ['0xa6eb7cdc219e1518ced964e9a34e61d68a94e4f1569db3e84256ba981ba52753'];
 export const EXPIRED_RFQ_ORDER_EVENT_TOPIC = ['0xd9ee00a67daf7d99c37893015dc900862c9a02650ef2d318697e502e5fb8bbe2'];
 export const MULTIPLEX_START_BLOCK = 12047508; // RANDOM BLOCK NUMBER FROM NOW FOR DATA PIPELINE TEST 
+export const UNISWAP_SWAP_EVENT_TOPIC = ['0xd78ad95fa46c994b6551d0da85fc275fe613ce37657fb8d5e3d130840159d822'];
 
 export const EXPIRED_RFQ_ORDER_ABI = {
     "anonymous": false,
@@ -464,5 +465,49 @@ export const V3_FILL_ABI = {
         }
     ],
     "name": "Fill",
+    "type": "event"
+};
+
+export const UNISWAP_SWAP_ABI =  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount0In",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount1In",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount0Out",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount1Out",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      }
+    ],
+    "name": "Swap",
     "type": "event"
 };

--- a/packages/event-pipeline/src/entities/index.ts
+++ b/packages/event-pipeline/src/entities/index.ts
@@ -30,3 +30,6 @@ export { V4RfqOrderFilledEvent } from './v4_rfq_order_filled_event';
 export { V4LimitOrderFilledEvent } from './v4_limit_order_filled_event';
 export { V4CancelEvent } from './v4_cancel_event';
 export { ExpiredRfqOrderEvent } from './expired_rfq_order_event';
+export { UniswapSwapEvent } from './uniswap_swap_event';
+
+export { UniswapPair } from './uniswap_pair';

--- a/packages/event-pipeline/src/entities/uniswap_pair.ts
+++ b/packages/event-pipeline/src/entities/uniswap_pair.ts
@@ -1,0 +1,20 @@
+import { Column, Entity, PrimaryColumn } from 'typeorm';
+
+import { numberToBigIntTransformer } from '../utils';
+
+// Class for Uniswap Pairs
+@Entity({ name: 'uniswap_pairs', schema: 'events' })
+export class UniswapPair {
+    // The address of the smart contract where this event was fired.
+    @PrimaryColumn({ name: 'contract_address' })
+    public contractAddress!: string;
+    // The address of token0.
+    @Column({ name: 'token0_address' })
+    public token0!: string;
+    // The address of token1.
+    @Column({ name: 'token1_address' })
+    public token1!: string;
+     // The block number where the event occurred.
+    @Column({ name: 'block_number', type: 'bigint', transformer: numberToBigIntTransformer })
+    public blockNumber!: number;
+}

--- a/packages/event-pipeline/src/entities/uniswap_swap_event.ts
+++ b/packages/event-pipeline/src/entities/uniswap_swap_event.ts
@@ -1,0 +1,27 @@
+import { BigNumber } from '@0x/utils';
+import { Column, Entity } from 'typeorm';
+
+import { Event } from './event';
+import { bigNumberTransformer } from '../utils';
+
+// These events come directly from the a Uniswap Pair contract and are fired whenever
+// someone swaps.
+@Entity({ name: 'uniswap_swap_events', schema: 'events' })
+export class UniswapSwapEvent extends Event {
+    // The amount of the token0 from the pair that was transfered in
+    @Column({ name: 'amount0_in', type: 'numeric', transformer: bigNumberTransformer })
+    public amount0In!: BigNumber;
+    // The amount of the token1 from the pair that was transfered in
+    @Column({ name: 'amount1_in', type: 'numeric', transformer: bigNumberTransformer })
+    public amount1In!: BigNumber;
+    // The amount of the token0 from the pair that was transfered out
+    @Column({ name: 'amount0_out', type: 'numeric', transformer: bigNumberTransformer })
+    public amount0Out!: BigNumber;
+    // The amount of the token1 from the pair that was transfered out
+    @Column({ name: 'amount1_out', type: 'numeric', transformer: bigNumberTransformer })
+    public amount1Out!: BigNumber;
+    @Column({ name: 'from', type: 'varchar' })
+    public from!: string;
+    @Column({ name: 'to', type: 'varchar' })
+    public to!: string;
+}

--- a/packages/event-pipeline/src/ormconfig.ts
+++ b/packages/event-pipeline/src/ormconfig.ts
@@ -32,7 +32,9 @@ import {
     V4LimitOrderFilledEvent,
     V4RfqOrderFilledEvent,
     ExpiredRfqOrderEvent,
-    V4CancelEvent
+    V4CancelEvent,
+    UniswapPair,
+    UniswapSwapEvent
 } from './entities';
 
 const entities = [
@@ -65,7 +67,9 @@ const entities = [
     V4LimitOrderFilledEvent,
     V4RfqOrderFilledEvent,
     ExpiredRfqOrderEvent,
-    V4CancelEvent
+    V4CancelEvent,
+    UniswapPair,
+    UniswapSwapEvent,
 ];
 
 const config: ConnectionOptions = {

--- a/packages/event-pipeline/src/parsers/events/uniswap_raw_events.ts
+++ b/packages/event-pipeline/src/parsers/events/uniswap_raw_events.ts
@@ -1,0 +1,25 @@
+const abiCoder = require('web3-eth-abi');
+import { RawLogEntry } from 'ethereum-types';
+import { UniswapSwapEvent } from '../../entities';
+import { parseEvent } from './parse_event';
+import { UNISWAP_SWAP_ABI } from '../../constants';
+import { BigNumber } from '@0x/utils';
+
+export function parseUniswapRawSwapEvent(eventLog: RawLogEntry): UniswapSwapEvent {
+    const uniswapSwapEvent = new UniswapSwapEvent();
+
+    parseEvent(eventLog, uniswapSwapEvent);
+
+    const decodedLog = abiCoder.decodeLog(UNISWAP_SWAP_ABI.inputs, eventLog.data, eventLog.topics.slice(1));
+
+    uniswapSwapEvent.amount0In = new BigNumber(decodedLog.amount0In);
+    uniswapSwapEvent.amount1In = new BigNumber(decodedLog.amount1In);
+    uniswapSwapEvent.amount0Out = new BigNumber(decodedLog.amount0Out);
+    uniswapSwapEvent.amount1Out = new BigNumber(decodedLog.amount1Out);
+    uniswapSwapEvent.from = decodedLog.sender.toLowerCase();
+    uniswapSwapEvent.to = decodedLog.to.toLowerCase();
+
+    return uniswapSwapEvent;
+}
+
+

--- a/packages/event-pipeline/src/scripts/pull_and_save_events_by_topic.ts
+++ b/packages/event-pipeline/src/scripts/pull_and_save_events_by_topic.ts
@@ -12,7 +12,8 @@ import {
     NativeFill, 
     FillEvent, 
     V4CancelEvent, 
-    ExpiredRfqOrderEvent
+    ExpiredRfqOrderEvent,
+    UniswapSwapEvent
 } from '../entities';
 
 import { ETHEREUM_RPC_URL, FIRST_SEARCH_BLOCK } from '../config';
@@ -30,7 +31,8 @@ import {
     V4_CANCEL_START_BLOCK,
     EXPIRED_RFQ_ORDER_EVENT_TOPIC,
     V4_CANCEL_EVENT_TOPIC,
-    MULTIPLEX_START_BLOCK
+    MULTIPLEX_START_BLOCK,
+    UNISWAP_SWAP_EVENT_TOPIC
 
 } from '../constants';
 
@@ -42,14 +44,17 @@ import { parseFillEvent } from '../parsers/events/fill_events';
 import { parseNativeFillFromFillEvent } from '../parsers/events/fill_events';
 import { parseV4CancelEvent } from '../parsers/events/v4_cancel_events';
 import { parseExpiredRfqOrderEvent } from '../parsers/events/expired_rfq_order_events';
+import { parseUniswapRawSwapEvent } from '../parsers/events/uniswap_raw_events';
 
 import { PullAndSaveEventsByTopic } from './utils/event_abi_utils';
+import { UniswapWatchedPairs } from './utils/uniswap_utils'
 
 const provider = web3Factory.getRpcProvider({
     rpcUrl: ETHEREUM_RPC_URL,
 });
 const web3Source = new Web3Source(provider, ETHEREUM_RPC_URL);
 const pullAndSaveEventsByTopic = new PullAndSaveEventsByTopic();
+const uniswapWatchedPairs = new UniswapWatchedPairs();
 
 export class EventsByTopicScraper {
     public async getParseSaveEventsAsync(connection: Connection): Promise<void> {
@@ -59,7 +64,8 @@ export class EventsByTopicScraper {
 
         logUtils.log(`latest block with offset: ${latestBlockWithOffset}`);
 
-        await Promise.all([
+
+        const eventsPromises = [
             pullAndSaveEventsByTopic.getParseSaveEventsByTopic<TransformedERC20Event>(connection, web3Source, latestBlockWithOffset, 'TransformedERC20Event', 'transformed_erc20_events', TRANSFORMEDERC20_EVENT_TOPIC, EXCHANGE_PROXY_ADDRESS, EXCHANGE_PROXY_DEPLOYMENT_BLOCK, parseTransformedERC20Event, {}),
             pullAndSaveEventsByTopic.getParseSaveEventsByTopic<ERC20BridgeTransferEvent>(connection, web3Source, latestBlockWithOffset, 'LiquidityProviderSwapEvent', 'erc20_bridge_transfer_events', LIQUIDITYPROVIDERSWAP_EVENT_TOPIC, EXCHANGE_PROXY_ADDRESS, PLP_VIP_START_BLOCK, parseLiquidityProviderSwapEvent, {isDirectTrade: true, directProtocol:'PLP'}),
             pullAndSaveEventsByTopic.getParseSaveEventsByTopic<V4RfqOrderFilledEvent>(connection, web3Source, latestBlockWithOffset, 'V4RfqOrderFilledEvent', 'v4_rfq_order_filled_events', RFQORDERFILLED_EVENT_TOPIC, EXCHANGE_PROXY_ADDRESS, V4_FILL_START_BLOCK, parseV4RfqOrderFilledEvent, {}),
@@ -70,8 +76,15 @@ export class EventsByTopicScraper {
             pullAndSaveEventsByTopic.getParseSaveEventsByTopic<NativeFill>(connection, web3Source, latestBlockWithOffset, 'NativeFillFromV3', 'native_fills', V3_FILL_EVENT_TOPIC, V3_EXCHANGE_ADDRESS, FIRST_SEARCH_BLOCK, parseNativeFillFromFillEvent, {protocolVersion:'v3'}),
             pullAndSaveEventsByTopic.getParseSaveEventsByTopic<V4CancelEvent>(connection, web3Source, latestBlockWithOffset, 'V4CancelEvent', 'v4_cancel_events', V4_CANCEL_EVENT_TOPIC, EXCHANGE_PROXY_ADDRESS, V4_CANCEL_START_BLOCK, parseV4CancelEvent, {}), 
             pullAndSaveEventsByTopic.getParseSaveEventsByTopic<ExpiredRfqOrderEvent>(connection, web3Source, latestBlockWithOffset, 'ExpiredRfqOrderEvent', 'expired_rfq_order_events', EXPIRED_RFQ_ORDER_EVENT_TOPIC, EXCHANGE_PROXY_ADDRESS, MULTIPLEX_START_BLOCK, parseExpiredRfqOrderEvent, {}), 
-        
-        ]);
+       ];
+
+        const uniswapPairs = await uniswapWatchedPairs.getUniswapWatchedPairs(connection);
+
+        const uniswapPromises = uniswapPairs.map(pair =>
+          pullAndSaveEventsByTopic.getParseSaveEventsByTopic<UniswapSwapEvent>(connection, web3Source, latestBlockWithOffset, 'UniswapSwapEvent', 'uniswap_swap_events', UNISWAP_SWAP_EVENT_TOPIC, pair.contractAddress, pair.blockNumber, parseUniswapRawSwapEvent, {})
+        );
+
+        await Promise.all([...eventsPromises, ...uniswapPromises]);
 
         const endTime = new Date().getTime();
         logUtils.log(`finished pulling events by topic`);

--- a/packages/event-pipeline/src/scripts/utils/uniswap_utils.ts
+++ b/packages/event-pipeline/src/scripts/utils/uniswap_utils.ts
@@ -1,0 +1,16 @@
+import { Connection } from 'typeorm';
+
+import { UniswapPair } from '../../entities';
+
+export class UniswapWatchedPairs {
+
+    public async getUniswapWatchedPairs(
+      connection: Connection
+      ): Promise<UniswapPair[]> {
+
+      const pairs = await connection.manager.find(UniswapPair);
+
+      return pairs;
+    }
+}
+


### PR DESCRIPTION
This is the first step in scraping Uniswap Swap events directly from the blockchain, without going through The Graph.

As an example it scrapes the ETH-USDT Pair, but it may allow to add new pairs  bay inserting inyo  the uniswap_pairs table. For this feature to be complete, the `_deleteOverlapAndSaveAsync` needs to be updated to delete not only by bloc, but also by contract.

The SQL VIEW `events.uniswap_swap_events_normalized` is included to display the data in a layout more consistent with the rest of the database.