### PR TITLE
fix maker<-->taker mix-up for univ3 events

### DIFF
--- a/event-pipeline-evm/Dockerfile
+++ b/event-pipeline-evm/Dockerfile
@@ -8,7 +8,7 @@ COPY pipeline-utils pipeline-utils
 COPY package.json yarn.lock tsconfig.json lerna.json ./
 RUN apk update && \
     apk upgrade && \
-    apk add --no-cache --virtual build-dependencies bash git openssh python make g++ && \
+    apk add --no-cache --virtual build-dependencies bash git openssh python3 make g++ && \
     yarn --frozen-lockfile --no-cache
 
 RUN yarn build

--- a/event-pipeline/Dockerfile
+++ b/event-pipeline/Dockerfile
@@ -8,7 +8,7 @@ COPY pipeline-utils pipeline-utils
 COPY package.json yarn.lock tsconfig.json lerna.json ./
 RUN apk update && \
     apk upgrade && \
-    apk add --no-cache --virtual build-dependencies bash git openssh python make g++ && \
+    apk add --no-cache --virtual build-dependencies bash git openssh python3 make g++ && \
     yarn --frozen-lockfile --no-cache
     
 RUN yarn build
@@ -26,9 +26,9 @@ COPY --from=build /usr/src/app/pipeline-utils/lib pipeline-utils/lib
 
 # Install event-pipeline runtime dependencies
 COPY event-pipeline/package.json event-pipeline/
-RUN apk add git python make g++ && \
+RUN apk add git python3 make g++ && \
     yarn install --frozen-lockfile --no-cache --production && \
-    apk del git python make g++
+    apk del git python3 make g++
 
 # Copy built files
 COPY --from=build /usr/src/app/event-pipeline/lib event-pipeline/lib/

--- a/event-pipeline/src/parsers/events/swap_events.ts
+++ b/event-pipeline/src/parsers/events/swap_events.ts
@@ -18,14 +18,14 @@ export function parseUniswapV3SwapEvent(eventLog: RawLogEntry): ERC20BridgeTrans
     // amount0 and amount1 are of opposite signs
     // neg value means token left the pool ie. maker
     // pos value means token entered the pool ie. taker
-    eRC20BridgeTransferEvent.fromToken = (decodedLog.amount0 >= 0) ? '0': '1' ; // taker_token
-    eRC20BridgeTransferEvent.toToken = (decodedLog.amount0 < 0) ? '0': '1' ; // maker_token
+    eRC20BridgeTransferEvent.fromToken = decodedLog.amount0 >= 0 ? '0' : '1'; // taker_token
+    eRC20BridgeTransferEvent.toToken = decodedLog.amount0 < 0 ? '0' : '1'; // maker_token
     eRC20BridgeTransferEvent.fromTokenAmount = decodedLog.amount0 >= 0 ? amount0 : amount1; // taker_token_amount
     eRC20BridgeTransferEvent.toTokenAmount = decodedLog.amount0 < 0 ? amount0 : amount1; // maker_token_amount
     eRC20BridgeTransferEvent.from = 'UniswapV3'; // maker
     eRC20BridgeTransferEvent.to = decodedLog.recipient.toLowerCase(); // taker
     eRC20BridgeTransferEvent.directFlag = true;
     eRC20BridgeTransferEvent.directProtocol = 'UniswapV3';
-    
+
     return eRC20BridgeTransferEvent;
 }

--- a/event-pipeline/src/parsers/events/swap_events.ts
+++ b/event-pipeline/src/parsers/events/swap_events.ts
@@ -12,15 +12,20 @@ export function parseUniswapV3SwapEvent(eventLog: RawLogEntry): ERC20BridgeTrans
     // decode the basic info directly into eRC20BridgeTransferEvent
     const decodedLog = abiCoder.decodeLog(SWAP_V3_ABI.inputs, eventLog.data, [eventLog.topics[1], eventLog.topics[2]]);
 
-    eRC20BridgeTransferEvent.fromToken = '1'; // taker_token
-    eRC20BridgeTransferEvent.toToken = '0'; // maker_token
+    const amount0 = new BigNumber(Math.abs(decodedLog.amount0));
+    const amount1 = new BigNumber(Math.abs(decodedLog.amount1));
 
-    eRC20BridgeTransferEvent.fromTokenAmount = new BigNumber(Math.abs(decodedLog.amount1)); // taker_token_amount
-    eRC20BridgeTransferEvent.toTokenAmount = new BigNumber(Math.abs(decodedLog.amount0)); // maker_token_amount
+    // amount0 and amount1 are of opposite signs
+    // neg value means token left the pool ie. maker
+    // pos value means token entered the pool ie. taker
+    eRC20BridgeTransferEvent.fromToken = (decodedLog.amount0 >= 0) ? '0': '1' ; // taker_token
+    eRC20BridgeTransferEvent.toToken = (decodedLog.amount0 < 0) ? '0': '1' ; // maker_token
+    eRC20BridgeTransferEvent.fromTokenAmount = decodedLog.amount0 >= 0 ? amount0 : amount1; // taker_token_amount
+    eRC20BridgeTransferEvent.toTokenAmount = decodedLog.amount0 < 0 ? amount0 : amount1; // maker_token_amount
     eRC20BridgeTransferEvent.from = 'UniswapV3'; // maker
     eRC20BridgeTransferEvent.to = decodedLog.recipient.toLowerCase(); // taker
     eRC20BridgeTransferEvent.directFlag = true;
     eRC20BridgeTransferEvent.directProtocol = 'UniswapV3';
-
+    
     return eRC20BridgeTransferEvent;
 }

--- a/staking-api/Dockerfile
+++ b/staking-api/Dockerfile
@@ -6,7 +6,7 @@ COPY staking-api staking-api
 COPY package.json yarn.lock tsconfig.json lerna.json ./
 RUN apk update && \
     apk upgrade && \
-    apk add --no-cache --virtual build-dependencies bash git openssh python make g++ && \
+    apk add --no-cache --virtual build-dependencies bash git openssh python3 make g++ && \
     yarn --frozen-lockfile --no-cache
     
 RUN yarn build


### PR DESCRIPTION
Fixing maker/taker bug in uni v3 events scraper.
We can't assume that token0 is always the maker/taker, this depends on whether the amount in the event log is positive or negative.

Simple fix implemented.